### PR TITLE
fix: ensure context is reset after leaving

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,6 @@ asgiref==3.8.1
     # via
     #   django
     #   django-stubs
-backports-tarfile==1.2.0
-    # via jaraco-context
 build==1.2.1
     # via -r requirements-dev.in
 certifi==2024.6.2
@@ -23,8 +21,6 @@ django-stubs-ext==5.0.2
     # via django-stubs
 docutils==0.21.2
     # via readme-renderer
-exceptiongroup==1.2.1
-    # via pytest
 factory-boy==3.3.0
     # via -r requirements-dev.in
 faker==26.0.0
@@ -32,10 +28,7 @@ faker==26.0.0
 idna==3.7
     # via requests
 importlib-metadata==8.0.0
-    # via
-    #   build
-    #   keyring
-    #   twine
+    # via twine
 iniconfig==2.0.0
     # via pytest
 jaraco-classes==3.4.0
@@ -103,18 +96,12 @@ six==1.16.0
     # via python-dateutil
 sqlparse==0.5.0
     # via django
-tomli==2.0.1
-    # via
-    #   build
-    #   django-stubs
-    #   pytest
 twine==5.1.1
     # via -r requirements-dev.in
 types-pyyaml==6.0.12.20240311
     # via django-stubs
 typing-extensions==4.12.2
     # via
-    #   asgiref
     #   django-stubs
     #   django-stubs-ext
 urllib3==2.2.2

--- a/tests/test_nplusones.py
+++ b/tests/test_nplusones.py
@@ -475,3 +475,13 @@ def test_works_in_web_requests(client):
     assert response.status_code == 200
     response = client.get(f"/user/{user_2.pk}/")
     assert response.status_code == 200
+
+
+def test_ignores_calls_on_different_lines():
+    [user_1, user_2] = UserFactory.create_batch(2)
+    PostFactory.create(author=user_1)
+    PostFactory.create(author=user_2)
+
+    # this should *not* raise an exception
+    _a = list(user_1.posts.all())
+    _b = list(user_2.posts.all())


### PR DESCRIPTION
before, exiting a `zealot_context` or calling `teardown()` would have the same effect as calling `zealot_ignore`, leading to a lot of false positives. this is no longer the case.

this PR also refactors how the listener handles context.